### PR TITLE
Fix Problem while using copy/paste function of plone

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,11 @@ Changelog
 4.1.3 (unreleased)
 ------------------
 
+- Add a better way in getting plone site root. A change in Archetypes setting
+  the creation date by a subscriber breaks the old way, because traversing
+  wasn't avaliable in such an early state.
+  [hoka]
+
 - Add a viewlet to mark the translated content as suggested by Google at
   http://googlewebmastercentral.blogspot.com.es/2011/12/new-markup-for-multilingual-content.html
   [erral]

--- a/Products/LinguaPlone/I18NBaseObject.py
+++ b/Products/LinguaPlone/I18NBaseObject.py
@@ -1,5 +1,6 @@
 from zope.event import notify
 from zope.interface import implements
+from zope.site.hooks import getSite
 
 from AccessControl import ClassSecurityInfo
 from Acquisition import Implicit
@@ -544,7 +545,8 @@ class I18NBaseObject(Implicit):
         if value is None:
             return []
 
-        tool = getToolByName(self, REFERENCE_CATALOG)
+        site = getSite()
+        tool = getToolByName(site, REFERENCE_CATALOG)
         _catalog = tool._catalog
         indexes = _catalog.indexes
 


### PR DESCRIPTION
So here again with a clean new fork.

---

Fix Problem while using copy/paste function of plone. Updating creation date with the help of subscribers.py is new to Archetypes. This way updating creation date causing an attribute error in Archetypes version 1.8.4. _queryBrains is called while pasting, but the pasted object is not avaliable to aquisition, so reference catalog can not found and raises an AttributeError
