### PR TITLE
Fixing CSRF protection bug on language-setup-folders view

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ Changelog
 
 - Use zope.interface decorator.
   [gforcada]
+  
+- Fixed CSRF protection bug on @@language-setup-folders view.
+  [syzn]
 
 
 4.1.4 (2016-02-17)

--- a/Products/LinguaPlone/browser/setup.py
+++ b/Products/LinguaPlone/browser/setup.py
@@ -4,6 +4,13 @@ from zope.interface import alsoProvides
 from Products.CMFCore.utils import getToolByName
 from Products.Five import BrowserView
 
+CSRF_PROTECTION_ENABLED = False
+try:
+    from plone.protect.interfaces import IDisableCSRFProtection
+    CSRF_PROTECTION_ENABLED = True
+except ImportError:
+    pass
+
 
 class SetupView(BrowserView):
 
@@ -12,6 +19,8 @@ class SetupView(BrowserView):
         self.previousDefaultPageId = None
 
     def __call__(self, forceOneLanguage=False):
+        if CSRF_PROTECTION_ENABLED:
+            alsoProvides(self.request, IDisableCSRFProtection)
         result = []
         self.folders = {}
         pl = getToolByName(self.context, "portal_languages")


### PR DESCRIPTION
This bug took me some hours to trace. So here is the story:

**Behaviour:**
On calling the `@@language-setup-folders` view LinguaPlone was telling me that it created the language folders but it did not.

**Reason:**
This is because CSRF allows this view to execute every step but seems to prevent it from saving to the database.

**Solution:**
Disable the CSRF protection for this view.

**Credits:**
All the credit goes to @jensens who brought me back on track. Thx!
