### PR TITLE
Fix hreflang links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,17 +4,10 @@ Changelog
 4.1.6 (unreleased)
 ------------------
 
-Breaking changes:
-
-- *add item here*
-
-New features:
-
-- *add item here*
-
 Bug fixes:
 
-- *add item here*
+- Show also current language link in header hreflang links.
+  [erral]
 
 
 4.1.5 (2016-08-11)

--- a/Products/LinguaPlone/browser/contentlinkviewlet.py
+++ b/Products/LinguaPlone/browser/contentlinkviewlet.py
@@ -9,9 +9,8 @@ class MultilingualContentViewlet(ViewletBase):
         # We have to check the view permission on the translated object, because
         # getTranslations returns all objects, no matter the workflow state
         context = aq_inner(self.context)
-        current = context.Language()
         _checkPermission = getSecurityManager().checkPermission
         self.translations = []
         for lang, content in context.getTranslations(review_state=False).items():
-            if lang != current and _checkPermission('View', content):
+            if _checkPermission('View', content):
                 self.translations.append(content)

--- a/Products/LinguaPlone/tests/test_contentlinkviewlet.py
+++ b/Products/LinguaPlone/tests/test_contentlinkviewlet.py
@@ -26,4 +26,4 @@ class TestContentLinkViewlet(LinguaPloneTestCase):
     def testViewletGeneratedLinks(self):
         viewlet = MultilingualContentViewlet(self.english, self.app.REQUEST, None, None)
         viewlet.update()
-        self.assertEqual(len(viewlet.translations), 1)
+        self.assertEqual(len(viewlet.translations), 2)


### PR DESCRIPTION
According to google's documentation, the hreflang links provided in the HTML should point to all versions of the contents, not only to the translations, as LP  does.

Documentation is here:

https://support.google.com/webmasters/answer/189077?hl=en

> If you have multiple language versions of a URL, each language page must identify all language versions, including itself.  For example, if your site provides content in French, English, and Spanish, the Spanish version must include a rel="alternate" hreflang="x" link for itself in addition to links to the French and English versions. Similarly, the English and French versions must each include the same references to the French, English, and Spanish versions.
