### PR TITLE
Show native language name in "Translate into..." menu

### DIFF
--- a/Products/LinguaPlone/browser/menu.py
+++ b/Products/LinguaPlone/browser/menu.py
@@ -48,7 +48,6 @@ class TranslateMenu(BrowserMenu):
         langs = self.getUntranslatedLanguages(context)
         if can_translate:
             showflags = lt.showFlags()
-            langs = self.getUntranslatedLanguages(context)
 
             for (lang_id, lang_name) in langs:
                 icon=showflags and lt.getFlagForLanguageCode(lang_id) or None

--- a/Products/LinguaPlone/browser/menu.py
+++ b/Products/LinguaPlone/browser/menu.py
@@ -1,5 +1,6 @@
 from plone.browserlayer.utils import registered_layers
 from zope.interface import implementer
+from zope.component import queryUtility
 from Products.CMFCore.permissions import AddPortalContent, ModifyPortalContent,\
     DeleteObjects
 
@@ -17,7 +18,7 @@ from Products.LinguaPlone import LinguaPloneMessageFactory as _
 from Products.LinguaPlone.browser.interfaces import ITranslateMenu
 from Products.LinguaPlone.browser.interfaces import ITranslateSubMenuItem
 from Products.LinguaPlone.interfaces import ILinguaPloneProductLayer
-
+from plone.i18n.locales.interfaces import IContentLanguageAvailability
 
 @implementer(ITranslateMenu)
 class TranslateMenu(BrowserMenu):
@@ -45,11 +46,19 @@ class TranslateMenu(BrowserMenu):
         if not (can_translate or can_set_language or can_delete):
             return []
 
+        lang_util = queryUtility(IContentLanguageAvailability)        
+        if lang_util is not None:
+            all_languages_dict = lang_util.getLanguages()
+
         langs = self.getUntranslatedLanguages(context)
         if can_translate:
             showflags = lt.showFlags()
 
             for (lang_id, lang_name) in langs:
+                if lang_util is not None:                    
+                    lang_info = all_languages_dict.get(lang_id, {})
+                    lang_name = lang_info.get('native', '') or lang_info.get('name')
+
                 icon=showflags and lt.getFlagForLanguageCode(lang_id) or None
                 item={
                     "title": lang_name,

--- a/Products/LinguaPlone/tests/test_menu.py
+++ b/Products/LinguaPlone/tests/test_menu.py
@@ -14,10 +14,10 @@ class TranslateMenuTests(LinguaPloneTestCase):
         self.assertEqual(doc.getLanguage(), 'en')
         menu = TranslateMenu('translations')
         self.assertEqual([i['title'] for i in menu.getMenuItems(doc, None)],
-            [u'German', u'label_manage_translations'])
+            [u'Deutsch', u'label_manage_translations'])
         self.addLanguage('no')
         self.assertEqual([i['title'] for i in menu.getMenuItems(doc, None)],
-            [u'German', u'Norwegian', u'label_manage_translations'])
+            [u'Deutsch', u'Norsk', u'label_manage_translations'])
 
     def testNeutralContentCannotBeTranslatedDirectly(self):
         self.folder.setLanguage('')


### PR DESCRIPTION
Some of our clients complain about showing the english language name on the "Translate into..." menu. 

I think that using the native language name instead of the english one would be better for content-editors.

Opinions?