### PR TITLE
Show translation linker pop-up contents from portal root

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,11 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- The breadcrumb shown on the translation linker pop-up shows the full site
+  [erral]
+
+- Translation linker pop-up is opened on the portal root
+  [erral]
 
 Bug fixes:
 

--- a/Products/LinguaPlone/skins/LinguaPlone/manage_translations_form.pt
+++ b/Products/LinguaPlone/skins/LinguaPlone/manage_translations_form.pt
@@ -145,7 +145,7 @@
                     </div>
 
                     <div class="field"
-                         tal:define="startup_directory context/absolute_url;
+                         tal:define="startup_directory context/portal_url;
                                      value request/link_content | nothing;
                                      fieldName string:link_content;
                                      fieldRealName fieldName;

--- a/Products/LinguaPlone/skins/LinguaPlone/translationbrowser_popup.pt
+++ b/Products/LinguaPlone/skins/LinguaPlone/translationbrowser_popup.pt
@@ -95,7 +95,7 @@
                      tal:condition= "python:search_text==''"
                      tal:define=    "portal here/portal_url/getPortalObject;
                                      putils nocall:portal/plone_utils;
-                                     crumbs python:putils.createBreadCrumbs(here);
+                                     crumbs context/translationbrowser_popup_full_breadcrumbs;
                                      isRTL context/@@plone_portal_state/is_rtl;
                                      parents request/PARENTS;
                                      nil python: parents.reverse();">

--- a/Products/LinguaPlone/skins/LinguaPlone/translationbrowser_popup_full_breadcrumbs.py
+++ b/Products/LinguaPlone/skins/LinguaPlone/translationbrowser_popup_full_breadcrumbs.py
@@ -1,0 +1,16 @@
+## Script (Python) "translationbrowser_popup_full_breadcrumbs"
+##bind container=container
+##bind context=context
+##bind namespace=
+##bind script=script
+##bind subpath=traverse_subpath
+##parameters=
+##title=Return full breadcrumbs from portal_root til context
+##
+items = []
+while context.portal_type != 'Plone Site':
+    items.append(context)
+    context = context.aq_parent
+
+items.reverse()
+return items


### PR DESCRIPTION
Some of our clients complain about the difficulty of using the translation linker pop-up.

The actual translation linker pop-up shows the contents of the context when it's opened. This does not make much sense because we are looking for content from another language, so we need to use the search form to reach the actual content.

Moreover the breadcrumb shown there stops in the nearest navigation root, which avoids browsing the site to go to the actual content and restricts you to use the search.

With these changes the pop-up opens on the root of the site and the breadcrumbs show the full site breadcrumb.

@nruiz @libargutxi 